### PR TITLE
Update "Degrees to Radians" and "Radians to Degrees" functions

### DIFF
--- a/table.tsv
+++ b/table.tsv
@@ -846,7 +846,7 @@ I(⌊1+⍟)J	Length to represent J in base I	Tacit	Dyadic Function		Mathematical
 (¯2○1○⊢)N	Complementary Angle	Tacit	Monadic Function		Circular/Trigonometric	○/		
 (1⍴⍨≢)Ym	Vector having as many ones as Ym has rows	Tacit	Monadic Function		Boolean/Logical	1s trues truths list		
 (*×⍨)N	Limit of nominal rate N when continuously compounded	Tacit	Monadic Function		Mathematical	interest		
-(180÷⍨○)N	N Degrees in Radians	Tacit	Monadic Function		Circular/Trigonometric			
+(○÷180)∘×N	N Degrees in Radians	Tacit	Monadic Function		Circular/Trigonometric			
 (!-∘1)N	Gamma function of N	Tacit	Monadic Function		Mathematical	gamma() Γ		
 (÷1∘○)N	Cosecant	Tacit	Monadic Function		Circular/Trigonometric	csc() cosec() cosecans		
 (÷2∘○)N	Secant	Tacit	Monadic Function		Circular/Trigonometric	sec() secans		
@@ -969,7 +969,7 @@ M(⊣×¯12○⊢)N	Join magnitude M and radians N to form complex	Tacit	Dyadic 
 (≢↑1∘↓)Y	Shifting Y left/up one position (padding on right/bottom)	Tacit	Dyadic Function		Selection	leftshift list vector 1		
 (1=≢∘⍴)Y	Is Y a vector?	Tacit	Monadic Function		Array Properties	testif rank1	https://tio.run/##SyzI0U2pTMzJT////1Hf1EdtExQ0DG0fdS561DHjUe8WTQV1j9ScnHx1LhySuCTU//8HAA	
 (⌊1+10∘⍟)J	Number of digits in strictly positive integers in J	Tacit	Monadic Function		Mathematical	needed positions width representation	https://tio.run/##SyzI0U2pTMzJT////1Hf1EdtExQ0HvV0GWobGjzqmPGod76mgqGZoYWCoYKRuaGFkcX//wA	
-(180÷○∘÷)N	N Radians in Degrees	Tacit	Monadic Function		Circular/Trigonometric			
+(÷○÷180)∘×N	N Radians in Degrees	Tacit	Monadic Function		Circular/Trigonometric			
 (○4×*∘2)N	Area of sphere with radius N	Tacit	Monadic Function		Circular/Trigonometric	length ball		
 (*∘÷∘3)N	Cube Root	Tacit	Monadic Function		Mathematical	squareroot cbrt ³√ ∛ ^0.333 ^.333 ^(1/3)		
 M×⍥(1∘-)N	Probabilistic NOR	Tacit	Dyadic Function		Mathematical	fuzzy probability chance peirce'sarrow quine'sdagger ampheck neithernor jointdenial Xpq ⊽		


### PR DESCRIPTION
This PR changes "N Degrees in Radians" and "N Radians in Degrees" functions.

Previous versions were:
1. N Degrees in Radians: `(180÷⍨○)N` (2 operations for each element of N)
2. N Radians in Degrees: `(180÷○∘÷)N` (3 operations for each element of N)

New versions are:
1. N Degrees in Radians: `(○÷180)∘×N`
2. N Radians in Degrees: `(÷○÷180)∘×N`

Both of them are multiplication by a scalar constant, which is faster.

### PR checklist:

- [x] from your APL session, check that the table is well-formatted
- [x] `]link.import # path/aplcart`
- [x] `Test'path/aplcart/table.tsv'` should return `1`
- [x] Fire up a local server and check that the site functions properly.